### PR TITLE
fix bug for axis location with missing chromosomes.

### DIFF
--- a/R/manhattan.R
+++ b/R/manhattan.R
@@ -114,7 +114,7 @@ manhattan <- function(x, chr="CHR", bp="BP", p="P", snp="SNP",
             # Old way: assumes SNPs evenly distributed
             # ticks=c(ticks, d[d$index==i, ]$pos[floor(length(d[d$index==i, ]$pos)/2)+1])
             # New way: doesn't make that assumption
-            ticks = c(ticks, (min(d[d$CHR == i,]$pos) + max(d[d$CHR == i,]$pos))/2 + 1)
+            ticks = c(ticks, (min(d[d$index == i,]$pos) + max(d[d$index == i,]$pos))/2 + 1)
         }
         xlabel = 'Chromosome'
         #labs = append(unique(d$CHR),'') ## I forgot what this was here for... if seems to work, remove.


### PR DESCRIPTION
Hi Stephen,

Thank you for developing this useful tool. I have been using this package with my GWAS results all the time. But recently I have a dataset with only limited number of chromosomes, (e.g., only variants on chromosome 1,3,8) and when I try to draw the manhattan plot, there is problem in showing the xlabels with wrong location.

I also found there is a similar issue reported by "bdvelie". I used his dataset and redraw the manhattan plot with my fix. Here is the result. 

Qian

```r
sd <- read.table("https://gist.githubusercontent.com/bdvelie/71d9245df7e9a21916f7/raw/Sample",header=TRUE)
manhattan(sd)
```
![new](https://cloud.githubusercontent.com/assets/12683977/7902431/83b0d904-0787-11e5-8843-949cae629300.png)
