### PR TITLE
Add posibility to control annotation font size.

### DIFF
--- a/R/manhattan.R
+++ b/R/manhattan.R
@@ -48,7 +48,7 @@
 manhattan <- function(x, chr="CHR", bp="BP", p="P", snp="SNP", 
                       col=c("gray10", "gray60"), chrlabs=NULL,
                       suggestiveline=-log10(1e-5), genomewideline=-log10(5e-8), 
-                      highlight=NULL, logp=TRUE, annotatePval = NULL, annotateTop = TRUE, fontSize = 1, ...) {
+                      highlight=NULL, logp=TRUE, annotatePval = NULL, annotateTop = TRUE, annotateFontSize = 0.45, ...) {
 
     # Not sure why, but package check will warn without this.
     CHR=BP=P=index=NULL
@@ -223,10 +223,10 @@ manhattan <- function(x, chr="CHR", bp="BP", p="P", snp="SNP",
         if (annotateTop == FALSE) {
           if (logp) {
               with(subset(d, P <= annotatePval), 
-                   textxy(pos, -log10(P), offset = 0.625, labs = topHits$SNP, cex = 0.45), ...)
+                   textxy(pos, -log10(P), offset = 0.625, labs = topHits$SNP, cex = annotateFontSize), ...)
           } else
               with(subset(d, P >= annotatePval), 
-                   textxy(pos, P, offset = 0.625, labs = topHits$SNP, cex = 0.45), ...)
+                   textxy(pos, P, offset = 0.625, labs = topHits$SNP, cex = annotateFontSize), ...)
         }
         else {
             # could try alternative, annotate top SNP of each sig chr
@@ -240,9 +240,9 @@ manhattan <- function(x, chr="CHR", bp="BP", p="P", snp="SNP",
                 
             }
             if (logp ){
-                textxy(topSNPs$pos, -log10(topSNPs$P), offset = 0.625, labs = topSNPs$SNP, cex = fontSize, ...)
+                textxy(topSNPs$pos, -log10(topSNPs$P), offset = 0.625, labs = topSNPs$SNP, cex = annotateFontSize, ...)
             } else
-              textxy(topSNPs$pos, topSNPs$P, offset = 0.625, labs = topSNPs$SNP, cex = fontSize, ...)
+              textxy(topSNPs$pos, topSNPs$P, offset = 0.625, labs = topSNPs$SNP, cex = annotateFontSize, ...)
         }
     }  
     par(xpd = FALSE)

--- a/R/manhattan.R
+++ b/R/manhattan.R
@@ -48,7 +48,7 @@
 manhattan <- function(x, chr="CHR", bp="BP", p="P", snp="SNP", 
                       col=c("gray10", "gray60"), chrlabs=NULL,
                       suggestiveline=-log10(1e-5), genomewideline=-log10(5e-8), 
-                      highlight=NULL, logp=TRUE, annotatePval = NULL, annotateTop = TRUE, ...) {
+                      highlight=NULL, logp=TRUE, annotatePval = NULL, annotateTop = TRUE, fontSize=1, ...) {
 
     # Not sure why, but package check will warn without this.
     CHR=BP=P=index=NULL
@@ -240,9 +240,9 @@ manhattan <- function(x, chr="CHR", bp="BP", p="P", snp="SNP",
                 
             }
             if (logp ){
-                textxy(topSNPs$pos, -log10(topSNPs$P), offset = 0.625, labs = topSNPs$SNP, cex = 0.5, ...)
+                textxy(topSNPs$pos, -log10(topSNPs$P), offset = 0.625, labs = topSNPs$SNP, cex = fontSize, ...)
             } else
-              textxy(topSNPs$pos, topSNPs$P, offset = 0.625, labs = topSNPs$SNP, cex = 0.5, ...)
+              textxy(topSNPs$pos, topSNPs$P, offset = 0.625, labs = topSNPs$SNP, cex = fontSize, ...)
         }
     }  
     par(xpd = FALSE)

--- a/R/manhattan.R
+++ b/R/manhattan.R
@@ -48,7 +48,7 @@
 manhattan <- function(x, chr="CHR", bp="BP", p="P", snp="SNP", 
                       col=c("gray10", "gray60"), chrlabs=NULL,
                       suggestiveline=-log10(1e-5), genomewideline=-log10(5e-8), 
-                      highlight=NULL, logp=TRUE, annotatePval = NULL, annotateTop = TRUE, fontSize=1, ...) {
+                      highlight=NULL, logp=TRUE, annotatePval = NULL, annotateTop = TRUE, fontSize = 1, ...) {
 
     # Not sure why, but package check will warn without this.
     CHR=BP=P=index=NULL


### PR DESCRIPTION
Hello Stephen,

I really like your package and find it very useful for creating aesthetic Manhattan plots. However, I miss the possibility to easily control the font size of SNP annotations. You can't do it using the `cex` parameter, so I added a new parameter, `annotateFontSize = 0.45`, to the function definition, which allows easy control of the annotation font size.