### PR TITLE
Bugfix: manhattan.R now indexes with BP, not SNP which should be an optional column

### DIFF
--- a/R/manhattan.R
+++ b/R/manhattan.R
@@ -95,7 +95,7 @@ manhattan <- function(x, chr="CHR", bp="BP", p="P", snp="SNP",
    #     ind = ind + 1
    #     d[d$CHR==i,]$index = ind
    # }
-   d$index = rep.int(seq_along(unique(d$CHR)), times = tapply(d$SNP,d$CHR,length))  # replcace the for loop of line 92-96 to improve efficiency
+   d$index = rep.int(seq_along(unique(d$CHR)), times = tapply(d$BP,d$CHR,length))  # replcace the for loop of line 92-96 to improve efficiency
     
     # This section sets up positions and ticks. Ticks should be placed in the
     # middle of a chromosome. The a new pos column is added that keeps a running


### PR DESCRIPTION
As the title suggests, the manhattan function does not require a SNP column, but when creating the index (to handle the cases where there are missing chromosomes), it uses the CHR and (possibly non-existent) SNP column. I have replaced the call to `d$SNP` with `d$BP`, which is a required column and produces the same result as using `d$SNP` (when it exists).

I'm honestly not sure how this has been broken for 7 years without a fix...